### PR TITLE
Fix delete item bug

### DIFF
--- a/server.py
+++ b/server.py
@@ -234,7 +234,6 @@ def list_orders_by_field():
     return make_response(jsonify(results), status.HTTP_200_OK)
 
 
-
 ######################################################################
 # LIST ALL ITEMS FROM AN ORDER
 ######################################################################
@@ -267,8 +266,8 @@ def delete_order(order_id):
 ######################################################################
 # DELETE AN ITEM FROM AN ORDER
 ######################################################################
-@app.route('/items/<int:item_id>', methods=['DELETE'])
-def delete_item(item_id):
+@app.route('/orders/<int:order_id>/items/<int:item_id>', methods=['DELETE'])
+def delete_item(order_id, item_id):
     """
     Delete an Item
 
@@ -276,8 +275,15 @@ def delete_item(item_id):
     the path
     """
     item = Item.get(item_id)
+    item_dict = item.serialize()
+    check_order_id = item_dict['order_id']
+    
+    if order_id != check_order_id:
+        raise NotFound("Item id '{}' has order id '{}' not '{}'.".format(item_id, check_order_id, order_id))
+
     if item:
         item.delete()
+
     return make_response('', status.HTTP_204_NO_CONTENT)
     
 
@@ -342,7 +348,6 @@ def cancel_orders(order_id):
 ######################################################################
 # UTILITY FUNCTIONS
 ######################################################################
-
 def init_db():
     """ Initialies the SQLAlchemy app """
     global app

--- a/server.py
+++ b/server.py
@@ -275,8 +275,7 @@ def delete_item(order_id, item_id):
     the path
     """
     item = Item.get(item_id)
-    item_dict = item.serialize()
-    check_order_id = item_dict['order_id']
+    check_order_id = item.order_id
     
     if order_id != check_order_id:
         raise NotFound("Item id '{}' has order id '{}' not '{}'.".format(item_id, check_order_id, order_id))
@@ -351,7 +350,6 @@ def cancel_orders(order_id):
 def init_db():
     """ Initialies the SQLAlchemy app """
     global app
-    # Item.init_db(app)
     Order.init_db(app)
 
 def check_content_type(content_type):
@@ -366,7 +364,6 @@ def initialize_logging(log_level=logging.INFO):
     if not app.debug:
         print 'Setting up logging...'
         # Set up default logging for submodules to use STDOUT
-        # datefmt='%m/%d/%Y %I:%M:%S %p'
         fmt = '[%(asctime)s] %(levelname)s in %(module)s: %(message)s'
         logging.basicConfig(stream=sys.stdout, level=log_level, format=fmt)
         # Make a new log handler that uses STDOUT

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -291,7 +291,7 @@ class TestServer(unittest.TestCase):
         self.assertEqual(new_json['name'], 'wrench')
 
     def test_delete_item(self):
-        """ Deleting an Item """
+        """ Deleting an Item from an Order"""
         item = Item.find_by_name('toilet paper')[0]
         
         # Save the current number of items for assertion
@@ -302,6 +302,10 @@ class TestServer(unittest.TestCase):
         self.assertEqual(len(resp.data), 0)
         new_count = self.get_item_count()
         self.assertEqual(new_count, item_count - 1)
+
+        resp = self.app.delete('/orders/{}/items/{}'.format(5, item.id),
+                               content_type='application/json')
+        self.assertEqual(resp.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
 
     def test_cancel_order(self):
         """ Cancel an existing Order """

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -268,13 +268,6 @@ class TestServer(unittest.TestCase):
         new_json = json.loads(resp.data)
         self.assertEqual(new_json['status'], 'shipped')
 
-    def test_cancel_order(self):
-        """ Cancel an existing Order """
-        resp = self.app.put('/orders/1/cancel', content_type='application/json')
-        self.assertEqual(resp.status_code, HTTP_200_OK)
-        new_json = json.loads(resp.data)
-        self.assertEqual(new_json['status'], 'cancelled')
-    
     def test_delete_order(self):
         """ Deleting an Order """
         order = Order.find_by_customer_id(1)[0]
@@ -299,18 +292,24 @@ class TestServer(unittest.TestCase):
 
     def test_delete_item(self):
         """ Deleting an Item """
-        item = Item()
-        # Using one of the existing test Items from setup
-        item.id = 2
+        item = Item.find_by_name('toilet paper')[0]
+        
         # Save the current number of items for assertion
         item_count = self.get_item_count()
-        resp = self.app.delete('/items/{}'.format(item.id),
+        resp = self.app.delete('/orders/{}/items/{}'.format(item.order_id, item.id),
                                content_type='application/json')
         self.assertEqual(resp.status_code, status.HTTP_204_NO_CONTENT)
         self.assertEqual(len(resp.data), 0)
         new_count = self.get_item_count()
         self.assertEqual(new_count, item_count - 1)
 
+    def test_cancel_order(self):
+        """ Cancel an existing Order """
+        resp = self.app.put('/orders/1/cancel', content_type='application/json')
+        self.assertEqual(resp.status_code, HTTP_200_OK)
+        new_json = json.loads(resp.data)
+        self.assertEqual(new_json['status'], 'cancelled')
+    
     def test_method_not_allowed(self):
         """ Call a Method thats not Allowed """
         resp = self.app.post('/orders/0')


### PR DESCRIPTION
Previously did not check order id even though item id is unique.  Now there is a proper route that first validates that the order id matches what the item details has for order id